### PR TITLE
Fix ISP target reset sequence

### DIFF
--- a/Projects/AVRISP-MKII/Lib/ISP/ISPTarget.c
+++ b/Projects/AVRISP-MKII/Lib/ISP/ISPTarget.c
@@ -279,7 +279,11 @@ void ISPTarget_ChangeTargetResetLine(const bool ResetTarget)
 	else
 	{
 		AUX_LINE_DDR  &= ~AUX_LINE_MASK;
-		AUX_LINE_PORT &= ~AUX_LINE_MASK;
+		
+		if ((V2Params_GetParameterValue(PARAM_RESET_POLARITY)))
+		  AUX_LINE_PORT |=  AUX_LINE_MASK;
+		else
+		  AUX_LINE_PORT &= ~AUX_LINE_MASK;
 	}
 }
 


### PR DESCRIPTION
ILDE level for CPU with negative reset polarity is logical one
